### PR TITLE
공통 응답 객체 추가

### DIFF
--- a/src/main/java/org/ormi/stackorflow/infra/common/AbstractResponse.java
+++ b/src/main/java/org/ormi/stackorflow/infra/common/AbstractResponse.java
@@ -4,6 +4,9 @@ import lombok.Getter;
 
 /**
  * 공통 응답 최상위 클래스 입니다.
+ * 기본적으로 응답 메시지와 결과 데이터를 담고 있습니다.
+ * {@link AbstractResponse<T>}
+ * @author 남대영
  */
 @Getter
 public abstract class AbstractResponse<T> {

--- a/src/main/java/org/ormi/stackorflow/infra/common/DefaultApiResponse.java
+++ b/src/main/java/org/ormi/stackorflow/infra/common/DefaultApiResponse.java
@@ -1,5 +1,13 @@
 package org.ormi.stackorflow.infra.common;
 
+/**
+ * 기본 응답 객체 입니다.
+ * 응답 메시지와 결과 데이터 이외에 데이터는 담지 않습니다.
+ * 추후 공통 응답 필드가 추가된다면 여기에 추가될 수 있습니다.
+ * {@link AbstractResponse<T>}
+ *
+ * @author skaeodud0507
+ */
 public final class DefaultApiResponse<T> extends AbstractResponse<T> {
 
   public DefaultApiResponse(String message, T result) {

--- a/src/main/java/org/ormi/stackorflow/infra/common/ErrorApiResponse.java
+++ b/src/main/java/org/ormi/stackorflow/infra/common/ErrorApiResponse.java
@@ -2,6 +2,13 @@ package org.ormi.stackorflow.infra.common;
 
 import lombok.Getter;
 
+/**
+ * 에러에 대한 공통 응답 입니다.
+ * 에러 메시지와 에러 코드를 가집니다.
+ * 에러 코드에 대한 구현은 추후 바뀔 수 있습니다.
+ *
+ * @author 남대영
+ */
 @Getter
 public class ErrorApiResponse<T> {
 

--- a/src/main/java/org/ormi/stackorflow/infra/common/PagedMetadata.java
+++ b/src/main/java/org/ormi/stackorflow/infra/common/PagedMetadata.java
@@ -1,7 +1,0 @@
-package org.ormi.stackorflow.infra.common;
-
-public record PagedMetadata(
-
-) {
-
-}

--- a/src/main/java/org/ormi/stackorflow/infra/common/PaginationApiResponse.java
+++ b/src/main/java/org/ormi/stackorflow/infra/common/PaginationApiResponse.java
@@ -3,6 +3,13 @@ package org.ormi.stackorflow.infra.common;
 import java.util.List;
 import lombok.Getter;
 
+/**
+ * 페이지네이션 응답에 대한 클래스 입니다.
+ * ReactQuery, Infinity Scroll 응답에 호환됩니다.
+ * {@link AbstractResponse<T>}
+ *
+ * @author 남대영
+ */
 @Getter
 public class PaginationApiResponse<T> extends AbstractResponse<List<T>> {
 

--- a/src/main/java/org/ormi/stackorflow/infra/common/Responses.java
+++ b/src/main/java/org/ormi/stackorflow/infra/common/Responses.java
@@ -5,6 +5,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 
+/**
+ * {@link ResponseEntity<T>}를 상속받은 응답 객체 중앙 클래스 입니다.
+ * 여러 타입의 응답 상황을 구현합니다.
+ *
+ * @author 남대영
+ */
 public class Responses<T> extends ResponseEntity<Object> {
 
   Responses(HttpStatusCode status, AbstractResponse<T> response) {
@@ -15,14 +21,35 @@ public class Responses<T> extends ResponseEntity<Object> {
     super(response, statusCode);
   }
 
-  public static <U> Responses<U> ok(String message) {
+  /**
+   * 성공 응답 객체를 만들지만 응답 데이터는 null 입니다.
+   *
+   * @param message 응답 메시지
+   * @return 성공 응답 데이터
+   */
+  public static Responses<Void> ok(String message) {
     return ok(message, null);
   }
 
+  /**
+   * 응답 메시지와 응답 데이터를 함께 생성합니다.
+   *
+   * @param message 응답 메시지
+   * @param result 응답 데이터
+   * @return 성공 응답 데이터
+   */
   public static <U> Responses<U> ok(String message, U result) {
     return of(HttpStatus.OK, message, result);
   }
 
+  /**
+   * 페이지네이션 응답 데이터를 생성합니다.
+   *
+   * @param message 응답 메시지
+   * @param result 응답 리스트 데이터
+   * @param pagedMetadata 페이지네이션 메타데이터
+   * @return 성공 응답 페이지네이션 데이터
+   */
   public static <U> Responses<List<U>> paginated(
       String message,
       List<U> result,
@@ -30,38 +57,96 @@ public class Responses<T> extends ResponseEntity<Object> {
   ) {
     return new Responses<>(HttpStatus.OK, new PaginationApiResponse<>(message, result, pagedMetadata));
   }
+
+  /**
+   * 201 응답을 생성 하지만 결과 데이터는 null 입니다.
+   *
+   * @param message 응답 메시지
+   * @return 201 성공응답 데이터
+   */
   public static <U> Responses<U> created(String message) {
     return of(HttpStatus.CREATED, message);
   }
 
+  /**
+   * 201 응답을 생성 하며, 응답 메시지와 결과 데이터도 함께 생성합니다.
+   *
+   * @param message 응답 메시지
+   * @param result 응답 결과
+   * @return 201 성공 응답 데이터
+   */
   public static <U> Responses<U> created(String message, U result) {
     return of(HttpStatus.CREATED, message, result);
   }
 
+  /**
+   * 400 에러 응답을 생성 하며, 응답 메시지만 생성합니다.
+   *
+   * @param message 응답 메시지
+   * @return 400 에러 응답 데이터
+   */
   public static <U> Responses<U> badRequest(String message) {
     return badRequest(message, null);
   }
 
+  /**
+   * 400 에러 응답을 생성 하며, 응답 메시지와 에러 코드를 생성합니다.
+   *
+   * @param message 응답 메시지
+   * @param errorCode 에러 코드
+   * @return 400 에러 응답 데이터
+   */
   public static <U> Responses<U> badRequest(String message, String errorCode) {
     return error(HttpStatus.BAD_REQUEST, message, errorCode);
   }
 
+  /**
+   * 에러 응답을 생성 하며, 에러 메시지만 생성 합니다.
+   *
+   * @param status 응답 상태 코드
+   * @param message 에러 메시지
+   * @return 에러 응답 데이터
+   */
   public static <U> Responses<U> error(HttpStatusCode status, String message) {
     return error(status, message, null);
   }
 
+  /**
+   * 에러 응답을 생성 하며, 에러 메시지와 에러 코드를 생성 합니다.
+   *
+   * @param status 응답 상태 코드
+   * @param message 에러 메시지
+   * @param errorCode 에러 코드
+   * @return 에러 응답 데이터
+   */
   public static <U> Responses<U> error(HttpStatusCode status, String message, String errorCode) {
     return new Responses<>(status, new ErrorApiResponse<>(message, errorCode));
   }
 
-  public static <U> Responses<U> of(HttpStatusCode statusCode, String message) {
-    return of(statusCode, message, null);
+  /**
+   * 응답 코드와 메시지로 응답 데이터를 생성합니다.
+   *
+   * @param status 응답 상태 코드
+   * @param message 응답 메시지
+   * @return 에러 응답 데이터
+   */
+  public static <U> Responses<U> of(HttpStatusCode status, String message) {
+    return of(status, message, null);
   }
 
-  public static <U> Responses<U> of(HttpStatusCode statusCode, String message, U result) {
-    if (statusCode.isError()) {
-      return error(statusCode, message);
+  /**
+   * 응답 코드와 메시지로 응답 데이터를 생성합니다.
+   * 응답 코드에 따라 error 응답이 생성 될 수 있습니다.
+   *
+   * @param status 응답 상태 코드
+   * @param message 응답 메시지
+   * @param result 응답 데이터
+   * @return 에러 응답 데이터
+   */
+  public static <U> Responses<U> of(HttpStatusCode status, String message, U result) {
+    if (status.isError()) {
+      return error(status, message);
     }
-    return new Responses<>(statusCode, new DefaultApiResponse<>(message, result));
+    return new Responses<>(status, new DefaultApiResponse<>(message, result));
   }
 }


### PR DESCRIPTION
# 공통 응답 객체

### 200 OK 기본
```java

@RestController
public class AnyController {

  @GetMapping("/ok")
  public Responses<String> ok() {
    return Responses.ok("성공적으로 조회하였습니다.", "성공 데이터");
  }

  @GetMapping("/ok2")
  public Responses<Person> okAndResponseData() {
    final Person person = anyService.getPerson(0L);
    return Responses.ok("성공적으로 조회하였습니다.", person);
  }
}

```

### 페이지네이션 응답
```java

@RestController
public class AnyController {

  @GetMapping("/ok")
  public Responses<List<String>> ok() {
    int currentPage = 1;
    int nextPage = 2;
    int totalItemSize = 100;
    boolean hasNext = true;
    
    return Responses.paginated(
      "성공적으로 조회하였습니다.", 
      List.of("응답데이터1", "데이터2"),
      PagedMetadata.of(currentPage, nextPage, totalItemSize, hasNext);
    );
  }
}

```

### 에러 응답
```java

@RestController
public class AnyController {
  private static final String ERROR_CODE1 = "ERR-1";

  @GetMapping("/ok")
  public Responses<String> ok() {
    
    return Responses.error(
      HttpStatus.NOT_FOUND,
      "에러 발생!",
       ERROR_CODE1
    );
  }
}

@RestController
public class AnyController {
  private static final String ERROR_CODE1 = "ERR-1";

  @GetMapping("/ok")
  public Responses<String> ok() {
    
    return Responses.badRequest(
      "에러 발생!",
       ERROR_CODE1
    );
  }
}
```

- 에러 응답에 대한 구현은 추후 변경 될 수 있음 !