### PR TITLE
feat(member, staff): 사용자, 스태프 도메인 개발

### DIFF
--- a/src/main/java/org/ormi/stackorflow/api/controller/member/MemberController.java
+++ b/src/main/java/org/ormi/stackorflow/api/controller/member/MemberController.java
@@ -1,0 +1,44 @@
+package org.ormi.stackorflow.api.controller.member;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.ormi.stackorflow.api.controller.member.response.MemberResponse;
+import org.ormi.stackorflow.core.domain.member.MemberService;
+import org.ormi.stackorflow.infra.common.Responses;
+import org.ormi.stackorflow.infra.member.MemberEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class MemberController {
+
+	private final MemberService memberService;
+
+	@GetMapping("/check-session")
+	public Responses<MemberResponse> checkSession(HttpSession httpSession) {
+
+		// 넘어온 세션 값이 DB에 존재한다면, 그냥 가져오고 없으면 insert
+		String sessionId = httpSession.getId();
+
+		if (!memberService.existsBySessionId(sessionId)) {
+			// 여기서 없으면 insert
+			return Responses.ok("사용자 세션 발급 성공", toMemberResponse(memberService.createSession(sessionId)));
+		}
+
+		// 있는 경우에 대한 로직
+		return Responses.ok("사용자 세션 가져오기 성공", toMemberResponse(memberService.getBySessionId(sessionId)));
+	}
+
+	public MemberResponse toMemberResponse(MemberEntity memberEntity) {
+		MemberResponse memberResponse = new MemberResponse();
+		memberResponse.setId(memberEntity.getId());
+		memberResponse.setSessionId(memberEntity.getSessionId());
+		memberResponse.setCode(memberEntity.getRole());
+
+		return memberResponse;
+	}
+
+}

--- a/src/main/java/org/ormi/stackorflow/api/controller/member/response/MemberResponse.java
+++ b/src/main/java/org/ormi/stackorflow/api/controller/member/response/MemberResponse.java
@@ -1,0 +1,14 @@
+package org.ormi.stackorflow.api.controller.member.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.ormi.stackorflow.core.domain.common.RoleType;
+
+@Getter
+@Setter
+public class MemberResponse {
+
+	private Long id;
+	private String sessionId;
+	private RoleType code;
+}

--- a/src/main/java/org/ormi/stackorflow/api/controller/staff/StaffController.java
+++ b/src/main/java/org/ormi/stackorflow/api/controller/staff/StaffController.java
@@ -1,0 +1,45 @@
+package org.ormi.stackorflow.api.controller.staff;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.ormi.stackorflow.api.controller.staff.response.StaffResponse;
+import org.ormi.stackorflow.core.domain.staff.StaffLogin;
+import org.ormi.stackorflow.core.domain.staff.StaffService;
+import org.ormi.stackorflow.infra.common.Responses;
+import org.ormi.stackorflow.infra.staff.StaffEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class StaffController {
+
+	private final StaffService staffService;
+
+	@PostMapping("/auth/staff/login")
+	public Responses<StaffResponse> staffLogin(@RequestBody StaffLogin staffLoginDto, HttpSession httpSession) {
+
+		// 요청으로 들어온 코드로 해당 스태프를 조회한다.
+		StaffEntity beforeStaffLogin = staffService.getByCode(staffLoginDto.getCertificationCode());
+
+		// 스탭 로그인 시, 세션 아이디 값을 meberId값에 넣어준다.
+		StaffEntity staffEntity = staffService.update(beforeStaffLogin, httpSession.getId());
+
+		return Responses.ok("성공적으로 스탭의 정보를 가져왔습니다.", toStaffResponse(staffEntity));
+	}
+
+	public StaffResponse toStaffResponse(StaffEntity staffEntity) {
+		StaffResponse staffResponse = new StaffResponse();
+		staffResponse.setId(staffEntity.getId());
+		staffResponse.setMemberId(staffEntity.getMemberEntity().getId());
+		staffResponse.setCode(staffEntity.getCode());
+		staffResponse.setNickname(staffEntity.getNickname());
+		staffResponse.setStaffRole(staffEntity.getStaffRole());
+
+		return staffResponse;
+	}
+
+}

--- a/src/main/java/org/ormi/stackorflow/api/controller/staff/response/StaffResponse.java
+++ b/src/main/java/org/ormi/stackorflow/api/controller/staff/response/StaffResponse.java
@@ -1,0 +1,16 @@
+package org.ormi.stackorflow.api.controller.staff.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.ormi.stackorflow.core.domain.common.RoleType;
+
+@Getter
+@Setter
+public class StaffResponse {
+
+	private int id;
+	private Long memberId;
+	private String code;
+	private String nickname;
+	private RoleType staffRole;
+}

--- a/src/main/java/org/ormi/stackorflow/core/domain/common/FilterConfig.java
+++ b/src/main/java/org/ormi/stackorflow/core/domain/common/FilterConfig.java
@@ -1,0 +1,20 @@
+package org.ormi.stackorflow.core.domain.common;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+	@Bean
+	public FilterRegistrationBean<SessionFilter> loggingFilter() {
+		FilterRegistrationBean<SessionFilter> registrationBean = new FilterRegistrationBean<>();
+
+		registrationBean.setFilter(new SessionFilter());
+		registrationBean.addUrlPatterns("/api/v1"); // 필터를 적용할 URL 패턴 설정
+		registrationBean.setOrder(1); // 필터의 순서 설정 (낮은 숫자가 높은 우선순위)
+
+		return registrationBean;
+	}
+}

--- a/src/main/java/org/ormi/stackorflow/core/domain/common/RoleType.java
+++ b/src/main/java/org/ormi/stackorflow/core/domain/common/RoleType.java
@@ -1,0 +1,5 @@
+package org.ormi.stackorflow.core.domain.common;
+
+public enum RoleType {
+	ANONYMOUS, STAFF, ADMIN, MANAGER, LECTURER, MENTOR;
+}

--- a/src/main/java/org/ormi/stackorflow/core/domain/common/SessionConst.java
+++ b/src/main/java/org/ormi/stackorflow/core/domain/common/SessionConst.java
@@ -1,0 +1,7 @@
+package org.ormi.stackorflow.core.domain.common;
+
+public class SessionConst {
+
+	public static final String ANONYMOUS_SESSION = "anonymous-session";
+
+}

--- a/src/main/java/org/ormi/stackorflow/core/domain/common/SessionFilter.java
+++ b/src/main/java/org/ormi/stackorflow/core/domain/common/SessionFilter.java
@@ -1,0 +1,57 @@
+package org.ormi.stackorflow.core.domain.common;
+
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SessionFilter implements Filter {
+
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+
+		HttpServletRequest request = (HttpServletRequest) servletRequest;
+		HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+		try {
+			HttpSession session = request.getSession(false);
+
+			if (session == null) {
+				// 세션이 없으면 세션 생성
+				session = request.getSession(true);
+				session.setAttribute(SessionConst.ANONYMOUS_SESSION, session);
+//				log.info("New session created with ID: " + session.getId());
+//				log.info("New session expired Date: " + session.getMaxInactiveInterval());
+			} else {
+				// 세션이 있으면 "ANONYMOUS_SESSION" 속성 확인 및 설정
+				Object sessionAttribute = session.getAttribute(SessionConst.ANONYMOUS_SESSION);
+				if (sessionAttribute == null) {
+					session.setAttribute(SessionConst.ANONYMOUS_SESSION, session);
+//					log.info("Existing session with ID: " + session.getId() + " and attribute set to existingSession");
+				} else {
+//					log.info("Existing session with ID: " + session.getId() + " and attribute: " + sessionAttribute);
+				}
+			}
+
+			// 필터 체인을 통해 요청을 다음 필터로 전달하거나 서블릿으로 전달
+			filterChain.doFilter(servletRequest, servletResponse);
+
+		} catch (Exception e) {
+			// 예외 발생 시 처리 로직
+			// 세션 발급에 실패할 경우에는 서버 측 문제일 가능성이 높기 때문에 500에러를 반환한다.
+//			log.info("Exception in SessionFilter: " + e.getMessage());
+			response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+			response.getWriter().write("Internal Server Error: " + e.getMessage());
+		}
+	}
+}

--- a/src/main/java/org/ormi/stackorflow/core/domain/common/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/org/ormi/stackorflow/core/domain/common/exception/ExceptionControllerAdvice.java
@@ -1,0 +1,10 @@
+package org.ormi.stackorflow.core.domain.common.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class ExceptionControllerAdvice {
+
+}

--- a/src/main/java/org/ormi/stackorflow/core/domain/common/exception/ResourceNotFoundException.java
+++ b/src/main/java/org/ormi/stackorflow/core/domain/common/exception/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package org.ormi.stackorflow.core.domain.common.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+	public ResourceNotFoundException(String datasource, String code) {
+		super(datasource + "에서 발급받은 code인 " + code + "를 찾을 수 없습니다.");
+	}
+}

--- a/src/main/java/org/ormi/stackorflow/core/domain/member/MemberCreate.java
+++ b/src/main/java/org/ormi/stackorflow/core/domain/member/MemberCreate.java
@@ -1,0 +1,19 @@
+package org.ormi.stackorflow.core.domain.member;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import org.ormi.stackorflow.core.domain.common.RoleType;
+
+@Getter
+public class MemberCreate {
+
+	private String id;
+	private RoleType role;
+
+	@Builder
+	public MemberCreate(String id, RoleType role) {
+		this.id = id;
+		this.role = role;
+	}
+}

--- a/src/main/java/org/ormi/stackorflow/core/domain/member/MemberService.java
+++ b/src/main/java/org/ormi/stackorflow/core/domain/member/MemberService.java
@@ -1,0 +1,36 @@
+package org.ormi.stackorflow.core.domain.member;
+
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.ormi.stackorflow.core.domain.common.RoleType;
+import org.ormi.stackorflow.core.domain.common.exception.ResourceNotFoundException;
+import org.ormi.stackorflow.infra.member.MemberEntity;
+import org.ormi.stackorflow.infra.member.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	public boolean existsBySessionId(String sessionId) {
+		return memberRepository.findBySessionId(sessionId).isPresent();
+	}
+
+	@Transactional
+	public MemberEntity createSession(String sessionId) {
+		MemberEntity memberEntity = new MemberEntity();
+		memberEntity.setSessionId(sessionId);
+		memberEntity.setRole(RoleType.ANONYMOUS);
+
+		return memberRepository.save(memberEntity);
+	}
+
+	@Transactional
+	public MemberEntity getBySessionId(String sessionId) {
+		return memberRepository.findBySessionId(sessionId)
+			.orElseThrow(() -> new ResourceNotFoundException("sessionId", sessionId));
+	}
+}

--- a/src/main/java/org/ormi/stackorflow/core/domain/staff/StaffLogin.java
+++ b/src/main/java/org/ormi/stackorflow/core/domain/staff/StaffLogin.java
@@ -1,0 +1,16 @@
+package org.ormi.stackorflow.core.domain.staff;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class StaffLogin {
+
+	private final String certificationCode;
+
+	@Builder
+	public StaffLogin(@JsonProperty("certificationCode") String certificationCode) {
+		this.certificationCode = certificationCode;
+	}
+}

--- a/src/main/java/org/ormi/stackorflow/core/domain/staff/StaffService.java
+++ b/src/main/java/org/ormi/stackorflow/core/domain/staff/StaffService.java
@@ -1,0 +1,34 @@
+package org.ormi.stackorflow.core.domain.staff;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.ormi.stackorflow.infra.staff.StaffRepository;
+import org.ormi.stackorflow.infra.member.MemberRepository;
+import org.ormi.stackorflow.infra.staff.StaffEntity;
+import org.ormi.stackorflow.infra.member.MemberEntity;
+import org.ormi.stackorflow.core.domain.common.exception.ResourceNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StaffService {
+
+	private final StaffRepository staffRepository;
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public StaffEntity getByCode(String certificationCode) {
+		return staffRepository.findByCode(certificationCode)
+			.orElseThrow(() -> new ResourceNotFoundException("Staff", certificationCode));
+	}
+
+	@Transactional
+	public StaffEntity update(StaffEntity staffEntity, String sessionId) {
+
+		MemberEntity memberEntity = memberRepository.findBySessionId(sessionId).get();
+		staffEntity.setMemberEntity(memberEntity);
+		staffEntity.updateMemberRole();
+
+		return staffEntity;
+	}
+}

--- a/src/main/java/org/ormi/stackorflow/infra/member/MemberEntity.java
+++ b/src/main/java/org/ormi/stackorflow/infra/member/MemberEntity.java
@@ -1,0 +1,38 @@
+package org.ormi.stackorflow.infra.member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.ormi.stackorflow.core.domain.common.RoleType;
+import org.ormi.stackorflow.infra.staff.StaffEntity;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "members")
+public class MemberEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_id")
+	private Long id;
+
+	@Column(name = "session_id")
+	private String sessionId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "role")
+	private RoleType role;
+
+	@OneToOne(mappedBy = "memberEntity")
+	private StaffEntity staffEntity;
+
+}

--- a/src/main/java/org/ormi/stackorflow/infra/member/MemberRepository.java
+++ b/src/main/java/org/ormi/stackorflow/infra/member/MemberRepository.java
@@ -1,0 +1,12 @@
+package org.ormi.stackorflow.infra.member;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
+
+	Optional<MemberEntity> findBySessionId(String sessionId);
+
+}

--- a/src/main/java/org/ormi/stackorflow/infra/staff/StaffEntity.java
+++ b/src/main/java/org/ormi/stackorflow/infra/staff/StaffEntity.java
@@ -1,0 +1,47 @@
+package org.ormi.stackorflow.infra.staff;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.ormi.stackorflow.core.domain.common.RoleType;
+import org.ormi.stackorflow.infra.member.MemberEntity;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "staffs")
+public class StaffEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "staff_id")
+	private int id;
+
+	@OneToOne
+	@JoinColumn(name = "member_id")
+	private MemberEntity memberEntity;
+
+	@Column(name = "code")
+	private String code;
+
+	@Column(name = "nickname")
+	private String nickname;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "staff_role")
+	private RoleType staffRole;
+
+
+	public void updateMemberRole() {
+		this.memberEntity.setRole(RoleType.STAFF);
+	}
+}

--- a/src/main/java/org/ormi/stackorflow/infra/staff/StaffRepository.java
+++ b/src/main/java/org/ormi/stackorflow/infra/staff/StaffRepository.java
@@ -1,0 +1,12 @@
+package org.ormi.stackorflow.infra.staff;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StaffRepository extends JpaRepository<StaffEntity, Integer> {
+
+	Optional<StaffEntity> findByCode(String code);
+
+}


### PR DESCRIPTION
사용자, 스태프 도메인 개발

기능 구현 리스트
- 메인페이지 접근 시 세션-쿠키 발급
- 익명 사용자 DB에 저장
- 스탭이 로그인할 경우 익명 사용자 DB에 role 업데이트, 스탭 정보를 return
